### PR TITLE
Misc cleanup

### DIFF
--- a/libcmmk.c
+++ b/libcmmk.c
@@ -44,8 +44,6 @@ enum {
 	CMMK_USB_EP_OUT = 0x83
 };
 
-static void hexdump(void const *ptr, size_t buflen);
-
 /* linear -> matrix */
 static int transpose(struct cmmk *dev, struct rgb const *linear, struct cmmk_color_matrix *matrix)
 {

--- a/libcmmk.c
+++ b/libcmmk.c
@@ -651,15 +651,23 @@ static int cmmk_from_row_col(struct cmmk *dev, unsigned row, unsigned col)
 }
 
 /*
- * Set the single key `key' (indized via enum cmmk_keycode) to the given color.
+ * Set the single key `key' to the given color.
+ */
+int cmmk_set_single_key_by_id(struct cmmk *dev, int key, struct rgb const *color)
+{
+	unsigned char data[64] = {0xc0, 0x01, 0x01, 0x00, key, color->R, color->G, color->B};
+
+	return send_command(dev->dev, data, sizeof(data));
+}
+
+/*
+ * Set the single key in row `row` and column `col` to the given color.
  */
 int cmmk_set_single_key(struct cmmk *dev, int row, int col, struct rgb const *color)
 {
 	int key = cmmk_from_row_col(dev, row, col);
 
-	unsigned char data[64] = {0xc0, 0x01, 0x01, 0x00, key, color->R, color->G, color->B};
-
-	return send_command(dev->dev, data, sizeof(data));
+	return cmmk_set_single_key_by_id(dev, key, color);
 }
 
 /*

--- a/libcmmk.h
+++ b/libcmmk.h
@@ -292,7 +292,12 @@ int cmmk_get_multilayer_map(struct cmmk *dev, struct cmmk_effect_matrix *effmap)
 int cmmk_set_multilayer_map(struct cmmk *dev, struct cmmk_effect_matrix const *effmap);
 
 /*
- * Set the single key `key' (indized via enum cmmk_keycode) to the given color.
+ * Set the single key `key' to the given color.
+ */
+int cmmk_set_single_key_by_id(struct cmmk *dev, int key, struct rgb const *color);
+
+/*
+ * Set the single key in row `row` and column `col` to the given color.
  */
 int cmmk_set_single_key(struct cmmk *dev, int row, int col, struct rgb const *color);
 


### PR DESCRIPTION
This restores the ability to set a single key by its ID instead of row/column index. This is necessary for creating new keymaps.

This also removes the apparently unused `hexdump` variable that my compiles warns me about.