### PR TITLE
Add MK750 support (EU/German)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ models are:
 
  * MasterKeys Pro L, EU / German
  * MasterKeys Pro S, US
+ * MasterKeys MK750, EU / German
 
 Implemented features:
   - Profile customization

--- a/keymap_eu.h
+++ b/keymap_eu.h
@@ -45,3 +45,33 @@ static keyboard_layout layout_eu_l = {
 	LCTRL LWIN LALT XXX XXX XXX SPACE XXX XXX XXX RALT RWIN FN XXX  RCTRL LEFT DOWN RIGHT #0   XXX #,   XXX */
 	{6,   90,  75,  -1, -1, -1, 91,   -1, -1, -1, 77,  78,  61, -1, 4,    95,  93,  5,    107, -1, 115, -1 }
 };
+
+static keyboard_layout layout_eu_mk750 = {
+	/*
+	ESC   F1    F2    F3    F4    XXX   F5    F6    F7    F8    XXX   F9    F10   F11   F12   PRN   SCL   PAU   MUT   PLA   REW   FWD   */
+	{96,  97,   98,   99,   104,  -1,   105,  106,  112,   113, -1,   114,  67,   68,   69,   102,  103,  107,  111,  110,  108,  109},
+
+	/*
+	^     1     2     3     4     5     6     7     8     9     0     ß     ´     XXX   BCK   INS   HOM   PUP   #LCK  #/    #*    #-    */
+	{0,   1,    8,    9,    16,   17,   24,   25,   32,   33,   40,   41,   48,   -1,   49,   56,   57,   64,   72,   73,   80,   81},
+
+	/*
+	TAB   Q     W     E     R     T     Z/Y   U     I     O     P     Ü/[   +/]   XXX   ENT   DEL   END   PDN   #7    #8    #9    #+    */
+	{2,   3,    10,   11,   18,   19,   26,   27,   34,   35,   42,   43,   50,   -1,   52,   58,   59,   66,   74,   75,   82,   83},
+
+	/*
+t 	CAP   A     S     D     F     G     H     J     K     L     Ö/;   Ä/'   #/C42 XXX   XXX   XXX   XXX   XXX   #4    #5     #6   XXX   */
+	{4,   5,    12,   13,   20,   21,   28,   29,   36,   37,   44,   45,   119,  -1,   -1,   -1,   -1,   -1,   76,   77,   84,   -1},
+
+	/*
+	LSHFT </C45 Y/Z   X     C     V     B     N     M     ,     .     -//   XXX   XXX   RSHFT XXX   UP    XXX   #1    #2    #3    #ENTER */
+	{6,   118,  7,    14,   15,   22,   23,   30,   31,   38,   39,   46,   -1,   -1,   47,   -1,   61,   -1,  78,   79,   86,    85},
+
+	/*
+	LCTRL LWIN  LALT  XXX   XXX   XXX   SPACE XXX   XXX   XXX   RALT  RWIN  FN    XXX   RCTRL LEFT  DOWN  RIGHT #0    XXX   #,    XXX    */
+	{91,  90,   92,   -1,   -1,   -1,   93,   -1,   -1,   -1,   53,   95,   60,   -1,   54,   63,   62,   70,   71,   -1,   87,   -1},
+
+	/*
+	XXX   LED1  LED2  LED3  LED4  XXX   LED6  LED7  LED8  LED9  LED10 LED11 LED12 LED13 LED14 LED15 XXX   LED17 LED18 LED19 LED20 XXX   */
+	{-1,  128,  140,  126,  141,  -1,   142,  125,  143,  151,  124,  123,  122,  150,  121,  120,  -1,   137,  135,  136,  138,  -1}
+};

--- a/keymap_us.h
+++ b/keymap_us.h
@@ -44,3 +44,5 @@ static keyboard_layout layout_us_s = {
 
 /* TODO */
 static keyboard_layout layout_us_l = { {-1}, {-1}, {-1}, {-1}, {-1}, {-1} };
+
+static keyboard_layout layout_us_mk750 = { {-1}, {-1}, {-1}, {-1}, {-1}, {-1} };

--- a/libcmmk.c
+++ b/libcmmk.c
@@ -30,8 +30,10 @@ typedef int16_t keyboard_layout[CMMK_ROWS_MAX][CMMK_COLS_MAX];
 static keyboard_layout const *keyboard_layouts[] = {
 	[CMMK_LAYOUT_US_S] = &layout_us_s,
 	[CMMK_LAYOUT_US_L] = &layout_us_l,
+	[CMMK_LAYOUT_US_MK750] = &layout_us_mk750,
 	[CMMK_LAYOUT_EU_S] = &layout_eu_s,
-	[CMMK_LAYOUT_EU_L] = &layout_eu_l
+	[CMMK_LAYOUT_EU_L] = &layout_eu_l,
+	[CMMK_LAYOUT_EU_MK750] = &layout_eu_mk750,
 };
 
 /* Some global definitions */

--- a/libcmmk.c
+++ b/libcmmk.c
@@ -22,7 +22,7 @@
 #include <libusb-1.0/libusb.h>
 
 /* Initialize keyboard layouts */
-typedef int8_t keyboard_layout[6][22];
+typedef int8_t keyboard_layout[CMMK_ROWS_MAX][CMMK_COLS_MAX];
 
 #include "keymap_eu.h"
 #include "keymap_us.h"
@@ -86,8 +86,8 @@ int transpose_reverse(struct cmmk *dev, struct cmmk_color_matrix const *matrix, 
 	int i;
 	int j;
 
-	for (i = 0; i < 6; ++i) {
-		for (j = 0; j < 22; ++j) {
+	for (i = 0; i < CMMK_ROWS_MAX; ++i) {
+		for (j = 0; j < CMMK_COLS_MAX; ++j) {
 			int pos = 0;
 
 			if ((pos = (*layout)[i][j]) < 0 || pos > CMMK_KEYLIST_SIZE) {
@@ -108,8 +108,8 @@ int transpose_effects_reverse(struct cmmk *dev, struct cmmk_effect_matrix const 
 	int i;
 	int j;
 
-	for (i = 0; i < 6; ++i) {
-		for (j = 0; j < 22; ++j) {
+	for (i = 0; i < CMMK_ROWS_MAX; ++i) {
+		for (j = 0; j < CMMK_COLS_MAX; ++j) {
 			int pos = 0;
 
 			if ((pos = (*layout)[i][j]) < 0 || pos > CMMK_KEYLIST_SIZE) {
@@ -173,8 +173,8 @@ int cmmk_attach(struct cmmk *state, int product, int layout)
 	memset(state->rowmap, -1, sizeof(state->rowmap));
 	memset(state->colmap, -1, sizeof(state->colmap));
 
-	for (i = 0; i < 6; ++i) {
-		for (j = 0; j < 22; ++j) {
+	for (i = 0; i < CMMK_ROWS_MAX; ++i) {
+		for (j = 0; j < CMMK_COLS_MAX; ++j) {
 			int p = (*keyboard_layout)[i][j];
 
 			if (p < 0) {

--- a/libcmmk.c
+++ b/libcmmk.c
@@ -22,7 +22,7 @@
 #include <libusb-1.0/libusb.h>
 
 /* Initialize keyboard layouts */
-typedef int8_t keyboard_layout[CMMK_ROWS_MAX][CMMK_COLS_MAX];
+typedef int16_t keyboard_layout[CMMK_ROWS_MAX][CMMK_COLS_MAX];
 
 #include "keymap_eu.h"
 #include "keymap_us.h"

--- a/libcmmk.h
+++ b/libcmmk.h
@@ -19,6 +19,9 @@
 
 #include <libusb-1.0/libusb.h>
 
+#define CMMK_ROWS_MAX 6
+#define CMMK_COLS_MAX 22
+
 #define CMMK_KEYLIST_SIZE 128 /* 8x16 RGB values => 128 distinct */
 
 /*
@@ -128,11 +131,11 @@ struct cmmk {
 
 /* Helper types because passing multi dim arrays as parameter is yucky */
 struct cmmk_color_matrix {
-	struct rgb data[6][22];
+	struct rgb data[CMMK_ROWS_MAX][CMMK_COLS_MAX];
 };
 
 struct cmmk_effect_matrix {
-	uint8_t data[6][22]; /* values as type of enum cmmk_effect_id */
+	uint8_t data[CMMK_ROWS_MAX][CMMK_COLS_MAX]; /* values as type of enum cmmk_effect_id */
 };
 
 /* Generic effect type for when type safety becomes too verbose.

--- a/libcmmk.h
+++ b/libcmmk.h
@@ -42,9 +42,11 @@ struct rgb {
 	unsigned char B;
 };
 
+
 enum cmmk_product {
 	CMMK_USB_MASTERKEYS_PRO_L = 0x003b,
-	CMMK_USB_MASTERKEYS_PRO_S = 0x003c
+	CMMK_USB_MASTERKEYS_PRO_S = 0x003c,
+	CMMK_USB_MASTERKEYS_MK750 = 0x0067,
 };
 
 enum cmmk_layout {

--- a/libcmmk.h
+++ b/libcmmk.h
@@ -19,7 +19,7 @@
 
 #include <libusb-1.0/libusb.h>
 
-#define CMMK_ROWS_MAX 6
+#define CMMK_ROWS_MAX 7
 #define CMMK_COLS_MAX 22
 
 #define CMMK_KEYLIST_SIZE 128 /* 8x16 RGB values => 128 distinct */

--- a/libcmmk.h
+++ b/libcmmk.h
@@ -52,8 +52,10 @@ enum cmmk_product {
 enum cmmk_layout {
 	CMMK_LAYOUT_US_S,
 	CMMK_LAYOUT_US_L, /* TODO */
+	CMMK_LAYOUT_US_MK750, /* TODO */
 	CMMK_LAYOUT_EU_S, /* TODO */
 	CMMK_LAYOUT_EU_L,
+	CMMK_LAYOUT_EU_MK750,
 
 	CMMK_LAYOUT_INVAL /* end marker */
 };

--- a/libcmmk.h
+++ b/libcmmk.h
@@ -22,7 +22,7 @@
 #define CMMK_ROWS_MAX 7
 #define CMMK_COLS_MAX 22
 
-#define CMMK_KEYLIST_SIZE 128 /* 8x16 RGB values => 128 distinct */
+#define CMMK_KEYLIST_SIZE 256
 
 /*
  * If we have C99 support (which we do, because libusb-1.0 requires it...), define some handy


### PR DESCRIPTION
This adds support for the MasterKeys MK750 keyboard. I had to increase the number of rows to 7, since this keyboard features an additional LED bar. I also had to make `keyboard_layout` an array of `int16_t` instead of `int8_t`, since key ids can be greater than 127 with this keyboard.